### PR TITLE
[#22] [Integration] As a user, when access token expired, application must automatically refresh it

### DIFF
--- a/Surveys.xcodeproj/project.pbxproj
+++ b/Surveys.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		5861161E292736D800EF52A4 /* SessionRepositorySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5861161C292736C800EF52A4 /* SessionRepositorySpec.swift */; };
 		5861162029273AB200EF52A4 /* StoreTokenUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5861161F29273AB200EF52A4 /* StoreTokenUseCaseSpec.swift */; };
 		5866FE042934545100908E86 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5866FE032934545100908E86 /* LoginViewModel.swift */; };
+		5868064F295D8C72009AC714 /* RefreshTokenParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5868064E295D8C72009AC714 /* RefreshTokenParameter.swift */; };
 		58683B1D29387D54005FD141 /* LoginViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58683B1A29387CCC005FD141 /* LoginViewModelSpec.swift */; };
 		58683B2029387EDC005FD141 /* Resolver+Domain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58683B1E29387ED7005FD141 /* Resolver+Domain.swift */; };
 		58683B2629388165005FD141 /* Combine+Collect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58683B2529388165005FD141 /* Combine+Collect.swift */; };
@@ -270,6 +271,7 @@
 		5861161C292736C800EF52A4 /* SessionRepositorySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRepositorySpec.swift; sourceTree = "<group>"; };
 		5861161F29273AB200EF52A4 /* StoreTokenUseCaseSpec.swift */ = {isa = PBXFileReference; indentWidth = 5; lastKnownFileType = sourcecode.swift; path = StoreTokenUseCaseSpec.swift; sourceTree = "<group>"; };
 		5866FE032934545100908E86 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
+		5868064E295D8C72009AC714 /* RefreshTokenParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshTokenParameter.swift; sourceTree = "<group>"; };
 		58683B1A29387CCC005FD141 /* LoginViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModelSpec.swift; sourceTree = "<group>"; };
 		58683B1E29387ED7005FD141 /* Resolver+Domain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Resolver+Domain.swift"; sourceTree = "<group>"; };
 		58683B2529388165005FD141 /* Combine+Collect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Combine+Collect.swift"; sourceTree = "<group>"; };
@@ -995,8 +997,9 @@
 		58C6C5A929222B410083AF17 /* Parameters */ = {
 			isa = PBXGroup;
 			children = (
-				58C6C5AA29222B520083AF17 /* LoginParameter.swift */,
 				58BF66EF293DD141003B1A82 /* ForgotPasswordParameter.swift */,
+				58C6C5AA29222B520083AF17 /* LoginParameter.swift */,
+				5868064E295D8C72009AC714 /* RefreshTokenParameter.swift */,
 				58C6EB17293ED9EE002A9B76 /* UserParameter.swift */,
 			);
 			path = Parameters;
@@ -1883,6 +1886,7 @@
 				5828F82B29260E800074FE82 /* Token.swift in Sources */,
 				5828F84F292620520074FE82 /* StoreTokenUseCase.swift in Sources */,
 				58BF66F0293DD141003B1A82 /* ForgotPasswordParameter.swift in Sources */,
+				5868064F295D8C72009AC714 /* RefreshTokenParameter.swift in Sources */,
 				583E2729295BDEBA0087E285 /* SurveyViewModel.swift in Sources */,
 				5880AE08291E3B8B00A212E7 /* ImageResource+Image.swift in Sources */,
 				58285B1C2939A9D200AC6E73 /* ForgotPasswordViewModel.swift in Sources */,

--- a/Surveys.xcodeproj/project.pbxproj
+++ b/Surveys.xcodeproj/project.pbxproj
@@ -129,6 +129,9 @@
 		58D1932F2941B79300D28082 /* GetTokenUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58D1932A2941B77A00D28082 /* GetTokenUseCaseSpec.swift */; };
 		58D193342941E27E00D28082 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58D193332941E27E00D28082 /* HomeViewModel.swift */; };
 		58D193372941E49B00D28082 /* HomeHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58D193362941E49B00D28082 /* HomeHeaderView.swift */; };
+		58E28144295EC712001BAABA /* Notification+Instance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E28143295EC712001BAABA /* Notification+Instance.swift */; };
+		58E28146295EC9B8001BAABA /* ObserveExpiredTokenUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E28145295EC9B8001BAABA /* ObserveExpiredTokenUseCase.swift */; };
+		58E28148295ECE41001BAABA /* ObserveExpiredTokenUseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E28147295ECE41001BAABA /* ObserveExpiredTokenUseCaseSpec.swift */; };
 		58F410FE29403C4600135DC7 /* GetHasLoggedInUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F410FD29403C4600135DC7 /* GetHasLoggedInUseCase.swift */; };
 		58F411002940690500135DC7 /* Constants+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F410FF2940690500135DC7 /* Constants+View.swift */; };
 		58F6E6122934AF2C00D0547A /* String+Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F6E6112934AF2C00D0547A /* String+Validation.swift */; };
@@ -327,6 +330,9 @@
 		58D1932C2941B78D00D28082 /* GetHasLoggedInUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetHasLoggedInUseCaseSpec.swift; sourceTree = "<group>"; };
 		58D193332941E27E00D28082 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		58D193362941E49B00D28082 /* HomeHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeHeaderView.swift; sourceTree = "<group>"; };
+		58E28143295EC712001BAABA /* Notification+Instance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+Instance.swift"; sourceTree = "<group>"; };
+		58E28145295EC9B8001BAABA /* ObserveExpiredTokenUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserveExpiredTokenUseCase.swift; sourceTree = "<group>"; };
+		58E28147295ECE41001BAABA /* ObserveExpiredTokenUseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserveExpiredTokenUseCaseSpec.swift; sourceTree = "<group>"; };
 		58F410FD29403C4600135DC7 /* GetHasLoggedInUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetHasLoggedInUseCase.swift; sourceTree = "<group>"; };
 		58F410FF2940690500135DC7 /* Constants+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Constants+View.swift"; sourceTree = "<group>"; };
 		58F6E6112934AF2C00D0547A /* String+Validation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Validation.swift"; sourceTree = "<group>"; };
@@ -621,6 +627,7 @@
 				58D193282941B72A00D28082 /* GetTokenUseCase.swift */,
 				5828F82D29260F0B0074FE82 /* LoginUseCase.swift */,
 				5828F84E292620520074FE82 /* StoreTokenUseCase.swift */,
+				58E28145295EC9B8001BAABA /* ObserveExpiredTokenUseCase.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -720,6 +727,7 @@
 				58D1932A2941B77A00D28082 /* GetTokenUseCaseSpec.swift */,
 				586116192927329400EF52A4 /* LoginUseCaseSpec.swift */,
 				5861161F29273AB200EF52A4 /* StoreTokenUseCaseSpec.swift */,
+				58E28147295ECE41001BAABA /* ObserveExpiredTokenUseCaseSpec.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -1121,6 +1129,7 @@
 				58BE09422925EA6700662F6C /* String+URL.swift */,
 				58F6E6112934AF2C00D0547A /* String+Validation.swift */,
 				581BDAF2294996970081BAE5 /* Bundle+Version.swift */,
+				58E28143295EC712001BAABA /* Notification+Instance.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -1770,6 +1779,7 @@
 				58C6EB12293DF7C6002A9B76 /* ForgotPasswordUseCaseSpec.swift in Sources */,
 				0C205FD636A87848DD90D15E /* AutoMockable.generated.swift in Sources */,
 				5828F85729262F600074FE82 /* Resolver+Data.swift in Sources */,
+				58E28148295ECE41001BAABA /* ObserveExpiredTokenUseCaseSpec.swift in Sources */,
 				588F1AA32923288C00AFBD5C /* NetworkAPIProtocolMock.swift in Sources */,
 				5828F859292630B40074FE82 /* Resolver+MockRegistering.swift in Sources */,
 				5891CDE1295D32A2006E3A69 /* SurveyViewModelSpec.swift in Sources */,
@@ -1798,6 +1808,7 @@
 				586ED15C2914EC3600181E14 /* SurveysApp.swift in Sources */,
 				581BDADD294824D70081BAE5 /* HomeSurveyItemView.swift in Sources */,
 				58B758622950551600CE2543 /* SurveyRepositoryProtocol.swift in Sources */,
+				58E28144295EC712001BAABA /* Notification+Instance.swift in Sources */,
 				58C6C5AB29222B530083AF17 /* LoginParameter.swift in Sources */,
 				5828F83429260FDF0074FE82 /* UserDefaultsManager.swift in Sources */,
 				8DD323BC8D45D5FC472505A8 /* Constants+API.swift in Sources */,
@@ -1892,6 +1903,7 @@
 				58285B1C2939A9D200AC6E73 /* ForgotPasswordViewModel.swift in Sources */,
 				58285B232939CCFF00AC6E73 /* View+Banner.swift in Sources */,
 				58285B1829399F6700AC6E73 /* Navigator.swift in Sources */,
+				58E28146295EC9B8001BAABA /* ObserveExpiredTokenUseCase.swift in Sources */,
 				5828F83129260F680074FE82 /* Resolver+Data.swift in Sources */,
 				58C6C5A329221CC90083AF17 /* RequestConfiguration.swift in Sources */,
 				FC1CE3FCD6AE97534C3BC5ED /* Typealiases.swift in Sources */,

--- a/Surveys/Sources/Constants/Constants.swift
+++ b/Surveys/Sources/Constants/Constants.swift
@@ -9,6 +9,7 @@ enum Constants {
     enum GrantType: String {
 
         case password
+        case refreshToken = "refresh_token"
     }
 
     enum Regex {}

--- a/Surveys/Sources/Data/NetworkAPI/Core/NetworkAPIError.swift
+++ b/Surveys/Sources/Data/NetworkAPI/Core/NetworkAPIError.swift
@@ -14,4 +14,5 @@ enum NetworkAPIError: Error, Equatable {
     case generic
     case dataNotFound
     case responseErrors(errors: [JSONAPIError])
+    case unauthenticated
 }

--- a/Surveys/Sources/Data/NetworkAPI/Core/NetworkAPIProtocol.swift
+++ b/Surveys/Sources/Data/NetworkAPI/Core/NetworkAPIProtocol.swift
@@ -15,21 +15,3 @@ protocol NetworkAPIProtocol {
 
     func performRequest<T: Decodable>(_ configuration: RequestConfiguration, for type: T.Type) -> Observable<T>
 }
-
-extension NetworkAPIProtocol {
-
-    func request<T: Decodable>(
-        _ configuration: RequestConfiguration,
-        provider: MoyaProvider<RequestConfiguration>,
-        decoder: JSONDecoder
-    ) -> Observable<T> {
-        return provider.requestPublisher(configuration)
-            .map { $0.data }
-            .decode(type: T.self, decoder: decoder)
-            .mapError { error -> Error in
-                guard let errors = error as? [JSONAPIError] else { return NetworkAPIError.generic }
-                return NetworkAPIError.responseErrors(errors: errors)
-            }
-            .eraseToAnyPublisher()
-    }
-}

--- a/Surveys/Sources/Data/NetworkAPI/Core/RequestConfiguration.swift
+++ b/Surveys/Sources/Data/NetworkAPI/Core/RequestConfiguration.swift
@@ -13,6 +13,7 @@ enum RequestConfiguration: Equatable {
 
     case login(LoginParameter)
     case forgotPassword(ForgotPasswordParameter)
+    case refreshToken(RefreshTokenParameter)
     case surveyDetail(String)
     case surveyList(Int, Int)
 }
@@ -21,7 +22,7 @@ extension RequestConfiguration: TargetType, AccessTokenAuthorizable {
 
     var authorizationType: Moya.AuthorizationType? {
         switch self {
-        case .login, .forgotPassword: return .none
+        case .login, .forgotPassword, .refreshToken: return .none
         case .surveyDetail, .surveyList: return .bearer
         }
     }
@@ -30,7 +31,7 @@ extension RequestConfiguration: TargetType, AccessTokenAuthorizable {
 
     var path: String {
         switch self {
-        case .login: return "oauth/token"
+        case .login, .refreshToken: return "oauth/token"
         case .forgotPassword: return "passwords"
         case .surveyList: return "surveys"
         case let .surveyDetail(surveyId):
@@ -41,15 +42,17 @@ extension RequestConfiguration: TargetType, AccessTokenAuthorizable {
     var method: Moya.Method {
         switch self {
         case .surveyDetail, .surveyList: return .get
-        case .forgotPassword, .login: return .post
+        case .forgotPassword, .login, .refreshToken: return .post
         }
     }
 
     var task: Moya.Task {
         switch self {
+        case let .forgotPassword(parameter):
+            return .requestParameters(parameters: parameter.dictionary, encoding: JSONEncoding.default)
         case let .login(parameter):
             return .requestParameters(parameters: parameter.dictionary, encoding: JSONEncoding.default)
-        case let .forgotPassword(parameter):
+        case let .refreshToken(parameter):
             return .requestParameters(parameters: parameter.dictionary, encoding: JSONEncoding.default)
         case .surveyDetail:
             return .requestPlain

--- a/Surveys/Sources/Data/NetworkAPI/NetworkAPI.swift
+++ b/Surveys/Sources/Data/NetworkAPI/NetworkAPI.swift
@@ -64,7 +64,6 @@ final class NetworkAPI: NetworkAPIProtocol {
         }
     }
 
-
     private func removeExpiredToken() {
         try? keychain.remove(.userToken)
     }

--- a/Surveys/Sources/Data/NetworkAPI/NetworkAPI.swift
+++ b/Surveys/Sources/Data/NetworkAPI/NetworkAPI.swift
@@ -10,8 +10,11 @@ import Combine
 import Foundation
 import JSONAPIMapper
 import Moya
+import Resolver
 
 final class NetworkAPI: NetworkAPIProtocol {
+
+    @Injected private var keychain: KeychainProtocol
 
     private let provider = MoyaProvider<RequestConfiguration>(plugins: [AuthPlugin()])
     private let decoder: JSONAPIDecoder
@@ -24,6 +27,56 @@ final class NetworkAPI: NetworkAPIProtocol {
         _ configuration: RequestConfiguration,
         for type: T.Type
     ) -> Observable<T> where T: Decodable {
-        request(configuration, provider: provider, decoder: JSONAPIDecoder.default)
+        provider.requestPublisher(configuration)
+            .map { self.checkExpiredToken($0, configuration) }
+            .asObservable()
+            .switchToLatest()
+            .map { $0.data }
+            .decode(type: T.self, decoder: decoder)
+            .mapError { error -> Error in
+                guard let errors = error as? [JSONAPIError] else { return NetworkAPIError.generic }
+                return NetworkAPIError.responseErrors(errors: errors)
+            }
+            .asObservable()
+    }
+
+    private func checkExpiredToken(
+        _ response: Response,
+        _ configuration: RequestConfiguration
+    ) -> Observable<Response> {
+        if response.statusCode == 401 {
+            guard let token: KeychainToken = try? keychain.get(.userToken),
+                  token.refreshToken.isNotEmpty else {
+                return Just(response).asObservable()
+            }
+            return refreshToken(token.refreshToken)
+                .flatMap { token in
+                    try? self.keychain.set(KeychainToken(token), for: .userToken)
+                    // Re-call failed API
+                    return self.provider.requestPublisher(configuration).asObservable()
+                }
+                .asObservable()
+        } else {
+            return Just(response).asObservable()
+        }
+    }
+
+    private func refreshToken(_ token: String) -> Observable<Token> {
+        let refreshTokenParameter = RefreshTokenParameter(
+            grantType: Constants.GrantType.refreshToken.rawValue,
+            refreshToken: token,
+            clientId: Constants.API.clientId,
+            clientSecret: Constants.API.clientSecret
+        )
+        let refreshTokenConfiguration = RequestConfiguration.refreshToken(refreshTokenParameter)
+        return provider.requestPublisher(refreshTokenConfiguration)
+            .map { $0.data }
+            .decode(type: APIToken.self, decoder: decoder)
+            .mapError { error -> Error in
+                guard let errors = error as? [JSONAPIError] else { return NetworkAPIError.generic }
+                return NetworkAPIError.responseErrors(errors: errors)
+            }
+            .compactMap { $0 as? Token }
+            .asObservable()
     }
 }

--- a/Surveys/Sources/Data/NetworkAPI/NetworkAPI.swift
+++ b/Surveys/Sources/Data/NetworkAPI/NetworkAPI.swift
@@ -14,6 +14,11 @@ import Resolver
 
 final class NetworkAPI: NetworkAPIProtocol {
 
+    enum StatusCode: Int {
+
+        case unauthenticated = 401
+    }
+
     @Injected private var keychain: KeychainProtocol
     @LazyInjected private var notificationCenter: NotificationCenter
 
@@ -45,11 +50,11 @@ final class NetworkAPI: NetworkAPIProtocol {
         _ response: Response,
         _ configuration: RequestConfiguration
     ) -> Observable<Response> {
-        if response.statusCode == 401 {
+        if response.statusCode == StatusCode.unauthenticated.rawValue {
             guard let token: KeychainToken = try? keychain.get(.userToken),
                   token.refreshToken.isNotEmpty else {
-                self.removeExpiredToken()
-                self.notifyExpiredToken()
+                removeExpiredToken()
+                notifyExpiredToken()
                 return Just(response).asObservable()
             }
             return refreshToken(token.refreshToken)

--- a/Surveys/Sources/Domain/Parameters/RefreshTokenParameter.swift
+++ b/Surveys/Sources/Domain/Parameters/RefreshTokenParameter.swift
@@ -1,0 +1,17 @@
+//
+//  RefreshTokenParameter.swift
+//  Surveys
+//
+//  Created by David Bui on 29/12/2022.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import Foundation
+
+struct RefreshTokenParameter: Parameterable, Codable, Equatable {
+
+    let grantType: String
+    let refreshToken: String
+    let clientId: String
+    let clientSecret: String
+}

--- a/Surveys/Sources/Domain/UseCases/ObserveExpiredTokenUseCase.swift
+++ b/Surveys/Sources/Domain/UseCases/ObserveExpiredTokenUseCase.swift
@@ -11,16 +11,16 @@ import Resolver
 
 // sourcery: AutoMockable
 protocol ObserveExpiredTokenUseCaseProtocol {
-
+    
     func execute() -> Observable<Void>
 }
 
 final class ObserveExpiredTokenUseCase: ObserveExpiredTokenUseCaseProtocol {
-
+    
     @Injected private var notificationCenter: NotificationCenter
-
+    
     func execute() -> Observable<Void> {
-        NotificationCenter.default.publisher(for: Notification.Name.unauthenticated)
+        notificationCenter.publisher(for: Notification.Name.unauthenticated)
             .map { _ in () }
             .asObservable()
     }

--- a/Surveys/Sources/Domain/UseCases/ObserveExpiredTokenUseCase.swift
+++ b/Surveys/Sources/Domain/UseCases/ObserveExpiredTokenUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  ObserveExpiredTokenUseCase.swift
+//  Surveys
+//
+//  Created by David Bui on 30/12/2022.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import Combine
+import Resolver
+
+// sourcery: AutoMockable
+protocol ObserveExpiredTokenUseCaseProtocol {
+
+    func execute() -> Observable<Void>
+}
+
+final class ObserveExpiredTokenUseCase: ObserveExpiredTokenUseCaseProtocol {
+
+    @Injected private var notificationCenter: NotificationCenter
+
+    func execute() -> Observable<Void> {
+        NotificationCenter.default.publisher(for: Notification.Name.unauthenticated)
+            .map { _ in () }
+            .asObservable()
+    }
+}

--- a/Surveys/Sources/Injection/Resolver+Data.swift
+++ b/Surveys/Sources/Injection/Resolver+Data.swift
@@ -23,6 +23,7 @@ extension Resolver {
     private static func registerServices() {
         register(SurveyCache.self) { SurveyCache() }
         register(KeychainProtocol.self) { Keychain.default }
+        register(NotificationCenter.self) { NotificationCenter.default }
         register(UserDefaultsManagerProtocol.self) { UserDefaultsManager.default }
         register(NetworkAPIProtocol.self) { NetworkAPI() }
     }

--- a/Surveys/Sources/Injection/Resolver+Domain.swift
+++ b/Surveys/Sources/Injection/Resolver+Domain.swift
@@ -21,6 +21,7 @@ extension Resolver {
         register(GetSurveyListUseCaseProtocol.self) { GetSurveyListUseCase() }
         register(GetTokenUseCaseProtocol.self) { GetTokenUseCase() }
         register(LoginUseCaseProtocol.self) { LoginUseCase() }
+        register(ObserveExpiredTokenUseCaseProtocol.self) { ObserveExpiredTokenUseCase() }
         register(StoreTokenUseCaseProtocol.self) { StoreTokenUseCase() }
     }
 }

--- a/Surveys/Sources/Presentation/Modules/Survey/SurveyView.swift
+++ b/Surveys/Sources/Presentation/Modules/Survey/SurveyView.swift
@@ -84,7 +84,9 @@ struct SurveyView: View {
                 PrimaryButton(
                     isEnabled: .constant(true),
                     isLoading: false,
-                    action: {},
+                    action: {
+                        NotificationCenter.default.post(.unauthenticated)
+                    },
                     title: Localize.surveyStartSurveyTitle()
                 )
                 .frame(width: 140.0)

--- a/Surveys/Sources/Presentation/Modules/Survey/SurveyView.swift
+++ b/Surveys/Sources/Presentation/Modules/Survey/SurveyView.swift
@@ -84,9 +84,7 @@ struct SurveyView: View {
                 PrimaryButton(
                     isEnabled: .constant(true),
                     isLoading: false,
-                    action: {
-                        NotificationCenter.default.post(.unauthenticated)
-                    },
+                    action: {},
                     title: Localize.surveyStartSurveyTitle()
                 )
                 .frame(width: 140.0)

--- a/Surveys/Sources/Presentation/Navigator/Navigator.swift
+++ b/Surveys/Sources/Presentation/Navigator/Navigator.swift
@@ -13,7 +13,17 @@ import SwiftUI
 
 final class Navigator: ObservableObject {
 
+    @Injected private var observeExpiredTokenUseCase: ObserveExpiredTokenUseCaseProtocol
+
     @Published var routes: Routes<Screen> = [.root(.splash)]
+
+    init() {
+        observeExpiredTokenUseCase.execute()
+            .receive(on: DispatchQueue.main)
+            .map { [.root(.login)] }
+            .asDriver()
+            .assign(to: &$routes)
+    }
 
     func show(screen: Screen, by transition: Transition, embedInNavigationView: Bool = false) {
         switch transition {

--- a/Surveys/Sources/Supports/Extensions/Foundation/Notification+Instance.swift
+++ b/Surveys/Sources/Supports/Extensions/Foundation/Notification+Instance.swift
@@ -1,0 +1,19 @@
+//
+//  Notification+Instance.swift
+//  Surveys
+//
+//  Created by David Bui on 30/12/2022.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import Foundation
+
+extension Notification {
+
+    static let unauthenticated = Notification(name: .unauthenticated)
+}
+
+extension Notification.Name {
+
+    static let unauthenticated = Notification.Name("unauthenticated")
+}

--- a/SurveysTests/Sources/Injection/Resolver+Domain.swift
+++ b/SurveysTests/Sources/Injection/Resolver+Domain.swift
@@ -27,6 +27,8 @@ extension Resolver {
             .implements(GetSurveyListUseCaseProtocol.self)
         mock.register { GetTokenUseCaseProtocolMock() }
             .implements(GetTokenUseCaseProtocol.self)
+        mock.register { ObserveExpiredTokenUseCaseProtocolMock() }
+            .implements(ObserveExpiredTokenUseCaseProtocol.self)
         mock.register { StoreTokenUseCaseProtocolMock() }
             .implements(StoreTokenUseCaseProtocol.self)
     }

--- a/SurveysTests/Sources/Specs/Domain/UseCases/ObserveExpiredTokenUseCaseSpec.swift
+++ b/SurveysTests/Sources/Specs/Domain/UseCases/ObserveExpiredTokenUseCaseSpec.swift
@@ -1,0 +1,47 @@
+//
+//  ObserveExpiredTokenUseCaseSpec.swift
+//  SurveysTests
+//
+//  Created by David Bui on 30/12/2022.
+//  Copyright © 2022 Nimble. All rights reserved.
+//
+
+import Combine
+import Nimble
+import Quick
+import Resolver
+
+@testable import Surveys
+
+final class ObserveExpiredTokenUseCaseSpec: QuickSpec {
+
+    override func spec() {
+
+        var useCase: ObserveExpiredTokenUseCase!
+
+        describe("A ObserveExpiredTokenUseCase") {
+
+            beforeEach {
+                Resolver.registerAllMockServices()
+                useCase = ObserveExpiredTokenUseCase()
+            }
+
+            describe("its execute() call") {
+
+                context("when notification center post unauthenticated notification") {
+                    var observeExpiredToken: Observable<Bool>!
+
+                    beforeEach {
+                        observeExpiredToken = useCase.execute().map { _ in true }.asObservable()
+                        NotificationCenter.default.post(.unauthenticated)
+                    }
+
+                    it("emits correct value") {
+                        let result = try self.awaitPublisher(observeExpiredToken)
+                        expect(result) == true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/SurveysTests/Sources/Specs/Domain/UseCases/ObserveExpiredTokenUseCaseSpec.swift
+++ b/SurveysTests/Sources/Specs/Domain/UseCases/ObserveExpiredTokenUseCaseSpec.swift
@@ -18,27 +18,28 @@ final class ObserveExpiredTokenUseCaseSpec: QuickSpec {
     override func spec() {
 
         var useCase: ObserveExpiredTokenUseCase!
+        var cancelBag: CancelBag!
 
         describe("A ObserveExpiredTokenUseCase") {
 
             beforeEach {
                 Resolver.registerAllMockServices()
                 useCase = ObserveExpiredTokenUseCase()
+                cancelBag = CancelBag()
             }
 
             describe("its execute() call") {
 
                 context("when notification center post unauthenticated notification") {
-                    var observeExpiredToken: Observable<Bool>!
-
-                    beforeEach {
-                        observeExpiredToken = useCase.execute().map { _ in true }.asObservable()
-                        NotificationCenter.default.post(.unauthenticated)
-                    }
 
                     it("emits correct value") {
-                        let result = try self.awaitPublisher(observeExpiredToken)
-                        expect(result) == true
+                        useCase.execute().map { _ in true }
+                            .sink { _ in
+                            } receiveValue: { expiredToken in
+                                expect(expiredToken) == true
+                            }
+                            .store(in: &cancelBag)
+                        NotificationCenter.default.post(.unauthenticated)
                     }
                 }
             }


### PR DESCRIPTION
- #22 

## What happened

- To avoid bad UX when user have to re-login. Application must automatically refresh access token when access token expired
 
## Insight

- Update RequestConfiguration: Add case refreshToken
- Create RefreshTokenParameter
- Update Constant.GrantType
- Update NetworkAPI to check 401 error and refresh token
- Create ObserveExpiredTokenUseCase
- Create Notification Extension Name
- Write UnitTest for ObserveExpiredTokenUseCase

## Proof Of Work

<img width="400" src="https://user-images.githubusercontent.com/24598204/210294121-d8c4da12-aa24-44d7-bc3c-869464297ea0.png">


