### PR TITLE
[#24] [UI] As a user, when tap on close button while in middle of answering survey question, I must see warning alert confirm 

### DIFF
--- a/Surveys/Resources/Localization/Localizable.strings
+++ b/Surveys/Resources/Localization/Localizable.strings
@@ -12,6 +12,7 @@
 "common.cancel.text" = "Cancel";
 "common.error.text" = "An error has occurred. Please try again later!";
 "common.ok.text" = "OK";
+"common.yes.text" = "Yes";
 
 "login.emailTextField.placeholder" = "Email";
 "login.forgotButton.title" = "Forgot?";
@@ -32,4 +33,6 @@
 
 "survey.startSurvey.title" = "Start Survey";
 
+"surveyQuestion.quitConfirm.text" = "Are you sure you want to quit the survey?";
 "surveyQuestion.submit.title" = "Submit";
+"surveyQuestion.warning.text" = "Warning!";

--- a/Surveys/Sources/Presentation/Modules/SurveyQuestions/SurveyQuestionsView.swift
+++ b/Surveys/Sources/Presentation/Modules/SurveyQuestions/SurveyQuestionsView.swift
@@ -17,6 +17,7 @@ struct SurveyQuestionsView: View {
 
     @State var selectedQuestionIndex = 0
     @State var isSubmittedViewPresented = false
+    @State var isQuitConfirmAlertPresented = false
 
     var isPresented: Binding<Bool>
 
@@ -50,6 +51,23 @@ struct SurveyQuestionsView: View {
             setUpNextQuestionButton()
             setUpQuestions()
         }
+        .alert(isPresented: $isQuitConfirmAlertPresented) {
+            Alert(
+                title: Text(Localize.surveyQuestionWarningText()),
+                message: Text(Localize.surveyQuestionQuitConfirmText()),
+                primaryButton: .default(
+                    Text(Localize.commonYesText())
+                        .font(.regular()),
+                    action: {
+                        isPresented.wrappedValue.toggle()
+                    }
+                ),
+                secondaryButton: .default(
+                    Text(Localize.commonCancelText())
+                        .font(.bold())
+                )
+            )
+        }
     }
 
     private func setUpBackground() -> some View {
@@ -78,7 +96,7 @@ struct SurveyQuestionsView: View {
                 Button(String.empty) {}
                     .modifier(RoundCloseButtonModifier(action: {
                         withAnimation {
-                            isPresented.wrappedValue.toggle()
+                            isQuitConfirmAlertPresented = true
                         }
                     }))
                     .padding(.top, 20.0)


### PR DESCRIPTION
- #24 

## What happened

- The user must see a warning alert to confirm quitting or survey when the user press the close button.
 
## Insight

- Update localizable strings
- Update presenting Confirm Alert when the user tap Close button and logic when the user select yes or cancel
 
## Proof Of Work

<img src=https://user-images.githubusercontent.com/24598204/210925005-09023dd6-fd7b-4b8b-8270-c55edc8ac220.png width=400>

https://user-images.githubusercontent.com/24598204/210925022-a32ca1e0-d06d-48ec-8a8d-3c9852cbe2d6.mp4

